### PR TITLE
fix(flow): Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,37 +1,38 @@
-<!--- Provide a general summary of the issue in the Title above -->
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
 
-## Description
-<!--- Provide a more detailed introduction to the issue itself, and why you consider it to be a bug -->
+---
 
-## Expected Behavior
-<!--- Tell us what should happen -->
+**Describe the bug**
+A clear and concise description of what the bug is.
 
-## Actual Behavior
-<!--- Tell us what happens instead -->
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
 
-## Steps to Reproduce
-<!--- Provide a link to a live example, or an unambiguous set of steps to -->
-<!--- reproduce this bug. Include code to reproduce, if relevant -->
-1.
-2.
-3.
-4.
+**Expected behavior**
+A clear and concise description of what you expected to happen.
 
-## Possible Fix
-<!--- Not obligatory, but suggest a fix or reason for the bug -->
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
 
-## Context
-<!--- How has this bug affected you? What were you trying to accomplish? -->
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
 
-## Your Environment
-<!--- Include as many relevant details about the environment you experienced the bug in -->
-* Version used:
-* Environment name and version (e.g. Chrome 39, node.js 5.4):
-* Operating System and version (desktop or mobile):
-* Link to your project:
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
 
-<!---
-Template based on one generated
-by TalAter's Issue and Pull Request Template Generator.
-Reproduced here under the MIT License.
--->
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,24 +1,20 @@
-<!--- Provide a general summary of the issue in the Title above -->
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
 
-## Detailed Description
-<!--- Provide a detailed description of the change or addition you are proposing -->
+---
 
-## Context
-<!--- Why is this change important to you? How would you use it? -->
-<!--- How can it benefit other users? -->
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
-## Possible Implementation
-<!--- Not obligatory, but suggest an idea for implementing addition or change -->
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
 
-## Your Environment
-<!--- Include as many relevant details about the environment you experienced the bug in -->
-* Version used:
-* Environment name and version (e.g. Chrome 39, node.js 5.4):
-* Operating System and version (desktop or mobile):
-* Link to your project:
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
 
-<!---
-Template based on one generated
-by TalAter's Issue and Pull Request Template Generator.
-Reproduced here under the MIT License.
--->
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
The templates I tried to create manually aren't working.
GitHub's docs recommend using their template builder.
I suspect that by using their builder, it will toggle some flag
that will enable templates in this project.

If this works, I'm not sure what this will mean for new projects
that clone from this one. Will they have to go through a similar process, or will templates "just work".

Unfortunately, this has to be merged to test it.

Related issue: #4 (close only after we know it works)