### PR TITLE
Fix document links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -214,10 +214,10 @@ They will review your work for the following characteristics in roughly
 this order:
 
 * The DCO has been signed-off on *_each commit_* by its author
-  (see [Commits and Their Messages](dev/commits-and-their-messages.adoc))
+  (see [Commits and Their Messages](docs/dev/commits-and-their-messages.md))
 * All tests pass.
 * The merge-request title and description comprise a good final merge
-  commit message (see [Commits and Their Messages](dev/commits-and-their-messages.adoc)).
+  commit message (see [Commits and Their Messages](docs/dev/commits-and-their-messages.md)).
 * The changes address the issues it claims to address;
   nothing more and nothing less.
 * New tests are provided the test the new code that has been developed.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Once you have based your project on this project, you should customize the follo
 
 ## Contributing
 
-Want to help? Great! Please see [CONTRIBUTING](CONTRIBUTING.adoc).
+Want to help? Great! Please see [CONTRIBUTING](CONTRIBUTING.md).
 
 ---
 Copyright (c) <YEAR> The LibreFoodPantry Developers.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Now issue a merge request back to your master and request a review.
 Once you have based your project on this project, you should customize the following files:
 
 - README.md (this one)
-- CONTRIBUTING.adoc
+- CONTRIBUTING.md
 
 
 ## Contributing


### PR DESCRIPTION
I updated the file extensions from .adoc to .md in all of the documents that used these. I also fixed any links that were previously broken from converting from .adoc .md and or moving files around in the repository.